### PR TITLE
Add example to demonstrate how to listen for changes  in CoBrowsing modes

### DIFF
--- a/js_sdk/listen_for_cobrowsing_start.js
+++ b/js_sdk/listen_for_cobrowsing_start.js
@@ -1,0 +1,18 @@
+sm.getApi({ version: 'v1' }).then(function (salemove) {
+  const customCommandEventListener = function (engagement) {
+    const coBrowseStateHanlder = function(cobrowsingState) {
+      if (cobrowsingState.mode === engagement.cobrowser.MODES.ENGAGEMENT) {
+        // when Operator sends an invite to the Visitor to CoBrowse
+        // and the Visitor accepts
+        // then it prints in the console a notification
+        console.log("CoBrowsing started")
+      }
+    }
+    
+  engagement.cobrowser.addBufferedEventListener(
+      engagement.cobrowser.EVENTS.MODE_CHANGE,
+      coBrowseStateHanlder
+    ); 
+  }
+  salemove.addEventListener(salemove.EVENTS.ENGAGEMENT_START, customCommandEventListener);
+});


### PR DESCRIPTION
It triggers a log in the console when CoBrowsing is accepted by the Visitor