### PR TITLE
Remove appointment_scheduled_at field

### DIFF
--- a/export_content/Glia Engagement End HTML export content.html
+++ b/export_content/Glia Engagement End HTML export content.html
@@ -80,9 +80,6 @@
 							<tr>
 								<td><b>CRM:</b>{crm_forwarded}</td>
 							</tr>
-							<tr>
-								<td><b>Appointment Date:</b>{appointment_scheduled_at}</td>
-							</tr>
 						</tbody>
 					</table>
 					<table border="0" cellpadding="0" cellspacing="0" style="width: 100%; margin: 0 auto; background: white; table-layout: fixed; padding-bottom: 15px;">

--- a/export_content/Glia Engagement End JSON export content.json
+++ b/export_content/Glia Engagement End JSON export content.json
@@ -14,7 +14,6 @@
   "engagementEndedAt": {engagement_ended_at},
   "engagementType": {engagement_type},
   "initiator": {initiator},
-  "appointmentScheduledAt": {appointment_scheduled_at},
   "cobrowsingUsed": {cobrowsing_used},
   "videoUsed": {video_used},
   "audioUsed": {audio_used},

--- a/export_content/Glia Engagement End XML export content.xml
+++ b/export_content/Glia Engagement End XML export content.xml
@@ -15,7 +15,6 @@
   <engagement_ended_at>{engagement_ended_at}</engagement_ended_at>
   <engagement_type>{engagement_type}</engagement_type>
   <initiator>{initiator}</initiator>
-  <appointment_scheduled_at>{appointment_scheduled_at}</appointment_scheduled_at>
   <cobrowsing_used>{cobrowsing_used}</cobrowsing_used>
   <video_used>{video_used}</video_used>
   <audio_used>{audio_used}</audio_used>


### PR DESCRIPTION
This commit removes reference to appointment_scheduled_at field. With
the implementation of the new surveys the support for
appointment_scheduled_at is lost and hence references will be removed.

OG-637