### PR TITLE
Fix error on hover menu cleanup

### DIFF
--- a/custom_code/hover_menu.js
+++ b/custom_code/hover_menu.js
@@ -143,7 +143,7 @@ var processMenuItem = function(menuItem, level, phoneMediaQueryList, right) {
 var processMenuItems = function() {
   var menuItems = document.querySelectorAll('.sky-mega-menu > *');
 
-  if (menuItems.length < 1) return;
+  if (menuItems.length < 1) return [];
   
   // Remember all menu items to remove event listeners after engagement ends
   var processedMenuItems = [];


### PR DESCRIPTION
When the menu was not on visitor page and engagement was ended,
then an error was thrown in console. This had no impact for the user.