### PR TITLE
Add a contributing file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing to examples
+
+We currently do not accept any contributions from external sources.
+
+The code is still open source and if you wish to add any changes, feel free to fork it and add changes to your fork.
+
+Issues for any security-related bugs found are still welcome, but we offer no guarantees on whether or when they will be acted upon.
+
+For any exceptional cases, please contact us at open-source@glia.com.


### PR DESCRIPTION
Our open source policy dictates that every public repository should have a contributing file. Add the default one here.

SEC-2232