### PR TITLE
Use public ECR for ruby image and upgrade patch version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 stage('Check WFM integration example') {
   withResultReporting(slackChannel: '#tm-cerebro') {
     inPod(containers: [
-      interactiveContainer(name: 'ruby', image: 'ruby:2.6.3')
+      interactiveContainer(name: 'ruby', image: 'public.ecr.aws/docker/library/ruby:2.6.7')
     ]) {
       checkout(scm)
       container('ruby') {


### PR DESCRIPTION
Dockerhub will heavily constrict its unauthorized pulls and to avert any possible issues from it we are migrating images to be pulled from ECR instead

DEVEXP-961