### PR TITLE
Assign codeowners to sales-engineers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @salemove/sales-engineers


### PR DESCRIPTION
This PR adds CODEOWNERS file and assigns sales-engineers as codeowners.